### PR TITLE
Change interface to conform with EventEmitter

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,7 +217,7 @@ class MiniPass extends EE {
     return dest
   }
 
-  addEventHandler (ev, fn) {
+  addListener (ev, fn) {
     return this.on(ev, fn)
   }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -190,8 +190,8 @@ t.test('end with chunk', async t => {
   let out = ''
   const mp = new MiniPass({ encoding: 'utf8' })
   let sawEnd = false
-  mp.on('end', _ => sawEnd = true)
-  mp.addEventHandler('data', c => out += c)
+  mp.prependListener('end', _ => sawEnd = true)
+  mp.addListener('data', c => out += c)
   let endCb = false
   mp.end('ok', _ => endCb = true)
   t.equal(out, 'ok')


### PR DESCRIPTION
Currently, this module offers an `addEventListener()` method along with `on()` to register listeners. While `on()` is something that users expect to have on a stream instance, `addEventListener()` is unexpected.

This pull request changes the interface to use the usual `addListener()` method like it is provided by `EventEmitter`.

**This is a breaking change and requires a major version bump.**