### PR TITLE
Use Buffer.from to avoid DEP005

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ class MiniPass extends EE {
     if (typeof chunk === 'string' && !this[OBJECTMODE] &&
         // unless it is a string already ready for us to use
         !(encoding === this[ENCODING] && !this[DECODER].lastNeed)) {
-      chunk = new Buffer(chunk, encoding)
+      chunk = Buffer.from(chunk, encoding)
     }
 
     if (Buffer.isBuffer(chunk) && this[ENCODING])

--- a/test/basic.js
+++ b/test/basic.js
@@ -40,7 +40,7 @@ t.test('unicode splitting', async t => {
   mp.on('data', chunk => {
     t.equal(chunk, butterfly)
   })
-  const butterbuf = new Buffer([0xf0, 0x9f, 0xa6, 0x8b])
+  const butterbuf = Buffer.from([0xf0, 0x9f, 0xa6, 0x8b])
   mp.write(butterbuf.slice(0, 1))
   mp.write(butterbuf.slice(1, 2))
   mp.write(butterbuf.slice(2, 3))
@@ -60,7 +60,7 @@ t.test('unicode splitting with setEncoding', async t => {
   mp.on('data', chunk => {
     t.equal(chunk, butterfly)
   })
-  const butterbuf = new Buffer([0xf0, 0x9f, 0xa6, 0x8b])
+  const butterbuf = Buffer.from([0xf0, 0x9f, 0xa6, 0x8b])
   mp.write(butterbuf.slice(0, 1))
   mp.write(butterbuf.slice(1, 2))
   mp.write(butterbuf.slice(2, 3))
@@ -77,7 +77,7 @@ t.test('base64 -> utf8 piping', t => {
   let out = ''
   dest.on('data', c => out += c)
   dest.on('end', _ =>
-    t.equal(new Buffer(out, 'base64').toString('utf8'), butterfly))
+    t.equal(Buffer.from(out, 'base64').toString('utf8'), butterfly))
   mp.write(butterfly)
   mp.end()
 })
@@ -91,7 +91,7 @@ t.test('utf8 -> base64 piping', t => {
   let out = ''
   dest.on('data', c => out += c)
   dest.on('end', _ =>
-    t.equal(new Buffer(out, 'base64').toString('utf8'), butterfly))
+    t.equal(Buffer.from(out, 'base64').toString('utf8'), butterfly))
   mp.write(butterfly)
   mp.end()
 })
@@ -101,7 +101,7 @@ t.test('read method', async t => {
   const mp = new MiniPass({ encoding: 'utf8' })
   mp.on('data', c => t.equal(c, butterfly))
   mp.pause()
-  mp.write(new Buffer(butterfly))
+  mp.write(Buffer.from(butterfly))
   t.equal(mp.read(5), null)
   t.equal(mp.read(0), null)
   t.same(mp.read(2), butterfly)
@@ -113,7 +113,7 @@ t.test('read with no args', async t => {
     const mp = new MiniPass({ encoding: 'utf8' })
     mp.on('data', c => t.equal(c, butterfly))
     mp.pause()
-    const butterbuf = new Buffer(butterfly)
+    const butterbuf = Buffer.from(butterfly)
     mp.write(butterbuf.slice(0, 2))
     mp.write(butterbuf.slice(2))
     t.same(mp.read(), butterfly)
@@ -121,7 +121,7 @@ t.test('read with no args', async t => {
   })
 
   t.test('buffer -> buffer', async t => {
-    const butterfly = new Buffer('🦋')
+    const butterfly = Buffer.from('🦋')
     const mp = new MiniPass()
     mp.on('data', c => t.same(c, butterfly))
     mp.pause()
@@ -133,7 +133,7 @@ t.test('read with no args', async t => {
 
   t.test('string -> buffer', async t => {
     const butterfly = '🦋'
-    const butterbuf = new Buffer(butterfly)
+    const butterbuf = Buffer.from(butterfly)
     const mp = new MiniPass()
     mp.on('data', c => t.same(c, butterbuf))
     mp.pause()
@@ -157,7 +157,7 @@ t.test('read with no args', async t => {
 t.test('partial read', async t => {
   const butterfly = '🦋'
   const mp = new MiniPass()
-  const butterbuf = new Buffer(butterfly)
+  const butterbuf = Buffer.from(butterfly)
   mp.write(butterbuf.slice(0, 1))
   mp.write(butterbuf.slice(1, 2))
   mp.write(butterbuf.slice(2, 3))
@@ -419,7 +419,7 @@ t.test('set encoding again throws', async t =>
 t.test('set encoding with existing buffer', async t => {
   const mp = new MiniPass()
   const butterfly = '🦋'
-  const butterbuf = new Buffer(butterfly)
+  const butterbuf = Buffer.from(butterfly)
   mp.write(butterbuf.slice(0, 1))
   mp.write(butterbuf.slice(1, 2))
   mp.setEncoding('utf8')


### PR DESCRIPTION
This remove the warning for [DEP005](https://github.com/nodejs/node/blob/master/doc/api/deprecations.md#dep0005-buffer-constructor).