### PR TITLE
add stream.concat() to collect into one chunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ mp.collect().then(all => {
 })
 ```
 
+### collecting into a single blob
+
+This is a bit slower because it concatenates the data into one chunk for
+you, but if you're going to do it yourself anyway, it's convenient this
+way:
+
+```js
+mp.concat().then(onebigchunk => {
+  // onebigchunk is a string if the stream
+  // had an encoding set, or a buffer otherwise.
+})
+```
+
 ### iteration
 
 You can iterate over streams synchronously or asynchronously in

--- a/index.js
+++ b/index.js
@@ -320,7 +320,7 @@ module.exports = class MiniPass extends EE {
       const buf = []
       this.on('data', c => buf.push(c))
       this.on('end', () => resolve(buf))
-      this.on('error', reject)
+      this.on('error', er => reject(er))
     })
   }
 

--- a/index.js
+++ b/index.js
@@ -324,6 +324,12 @@ module.exports = class MiniPass extends EE {
     })
   }
 
+  // const data = await stream.concat()
+  concat () {
+    return this.collect().then(chunks =>
+      this[ENCODING] ? chunks.join('') : Buffer.concat(chunks))
+  }
+
   // for await (let chunk of stream)
   [ASYNCITERATOR] () {
     const next = () => {

--- a/test/collect.js
+++ b/test/collect.js
@@ -24,3 +24,20 @@ t.test('error', async t => {
   setTimeout(() => mp.emit('error', poop))
   await t.rejects(mp.collect(), poop)
 })
+
+t.test('concat strings', async t => {
+  const mp = new MP({ encoding: 'utf8' })
+  mp.write('foo')
+  mp.write('bar')
+  mp.write('baz')
+  mp.end()
+  await t.resolveMatch(mp.concat(), 'foobarbaz')
+})
+t.test('concat buffers', async t => {
+  const mp = new MP()
+  mp.write('foo')
+  mp.write('bar')
+  mp.write('baz')
+  mp.end()
+  await t.resolveMatch(mp.concat(), Buffer.from('foobarbaz'))
+})


### PR DESCRIPTION
I can see this potentially being very useful, since  most `stream.collect()` use cases are going to want to join the data together.

My only hesitation is that `stream.concat()` kind of sounds like it's concatenating streams (or chunks) together into a new stream, like `Array.concat()`.  Maybe there's a better name for it?  or maybe this is fine?