### PR TITLE
Add missing content to variable on README's example

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ class NDJSONDecode extends Minipass {
     const jsonData = (this._jsonBuffer + chunk).split('\n')
     this._jsonBuffer = jsonData.pop()
     for (let i = 0; i < jsonData.length; i++) {
-      let parsed
+      let parsed = jsonData[i]
       try {
         super.write(parsed)
       } catch (er) {


### PR DESCRIPTION
Add content to the "parsed" variable on the "transform that parses newline-delimited JSON" example.
Fixes #16 