### PR TITLE
    buffer chunk after flushing buffer in write if paused

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,7 +165,12 @@ module.exports = class Minipass extends Stream {
       // because we're mid-write, so that'd be bad.
       if (this[BUFFERLENGTH] !== 0)
         this[FLUSH](true)
-      this.emit('data', chunk)
+
+      // if we are still flowing after flushing the buffer we can emit the
+      // chunk otherwise we have to buffer it.
+      this.flowing
+        ? this.emit('data', chunk)
+        : this[BUFFERPUSH](chunk)
     } else
       this[BUFFERPUSH](chunk)
 

--- a/test/buffer-chunk-when-flowing-stops.js
+++ b/test/buffer-chunk-when-flowing-stops.js
@@ -1,0 +1,35 @@
+// Reproduces an issue where write is called while the stream is flowing but a
+// destination cannot accept all of the buffered chunks.  minipass should add
+// the chunk to the end of the buffer instead of emitting it before the buffer
+// is cleared.
+//
+// This caused issues when piping make-fetch-happen stream to tar.extract
+// https://github.com/npm/cli/issues/3884
+const Minipass = require('../')
+const t = require('tap')
+
+class Pauser extends Minipass {
+  write (chunk, encoding, callback) {
+    super.write(chunk, encoding, callback)
+    return false
+  }
+}
+
+const src = new Minipass({encoding: 'utf8'})
+const pauser = new Pauser({encoding: 'utf8'})
+
+// queue up two chunks while the src is buffering
+src.write('1')
+src.write('2')
+
+// when the src starts flowing write a third chunk
+src.once('resume', () => src.write('3'))
+
+// pipe the src to the pauser which will request the src stops after the first
+// chunk.
+src.pipe(pauser)
+
+src.end()
+
+// we should expect the chunks in the original order.
+t.resolveMatch(pauser.collect(), ['1', '2', '3'], '123')


### PR DESCRIPTION


4c5a106 handled a convoluted case where there is a chunk in the buffer
AND  we're in a flowing state during a write call which caused out of
order writes.

The fix was to flush the buffer before emitting the new chunk, but it
didn't account for destinations pausing the stream after flushing part
of the buffer. This caused issues in npm / pacote / npm-registry-fetch.

That specific issue is demonstrated in everett1992/make-fetch-happen-tar-extract-error
and occurs when make-fetch-happen res.body is piped to a tar.extract
stream.

Fixes isaacs/minipass#27, npm/cli#3884, npm/make-fetch-happen#63