### PR TITLE
[Type Definitions] Change ES6 exports to CommonJS

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,39 +2,71 @@
 import { EventEmitter } from 'events'
 import { Stream } from 'stream'
 
-export type Encoding = BufferEncoding | 'buffer' | null
+declare namespace Minipass {
+  type Encoding = BufferEncoding | 'buffer' | null
 
-interface Writable extends EventEmitter {
-  end(): any
-  write(chunk: any, ...args: any[]): any
+  interface Writable extends EventEmitter {
+    end(): any
+    write(chunk: any, ...args: any[]): any
+  }
+
+  interface Readable extends EventEmitter {
+    pause(): any
+    resume(): any
+    pipe(): any
+  }
+
+  interface Pipe<R, W> {
+    src: Minipass<R, W>
+    dest: Writable
+    opts: PipeOptions
+  }
+
+  type DualIterable<T> = Iterable<T> & AsyncIterable<T>
+
+  type ContiguousData = Buffer | ArrayBufferLike | ArrayBufferView | string
+
+  type BufferOrString = Buffer | string
+
+  interface StringOptions {
+    encoding: BufferEncoding
+    objectMode?: boolean
+    async?: boolean
+  }
+
+  interface BufferOptions {
+    encoding?: null | 'buffer'
+    objectMode?: boolean
+    async?: boolean
+  }
+
+  interface ObjectModeOptions {
+    objectMode: true
+    async?: boolean
+  }
+
+  interface PipeOptions {
+    end?: boolean
+    proxyErrors?: boolean
+  }
+
+  type Options<T> = T extends string
+    ? StringOptions
+    : T extends Buffer
+    ? BufferOptions
+    : ObjectModeOptions
 }
 
-interface Readable extends EventEmitter {
-  pause(): any
-  resume(): any
-  pipe(): any
-}
-
-interface Pipe<R, W> {
-  src: Minipass<R, W>
-  dest: Writable
-  opts: PipeOptions
-}
-
-type DualIterable<T> = Iterable<T> & AsyncIterable<T>
-
-type ContiguousData = Buffer | ArrayBufferLike | ArrayBufferView | string
-
-type BufferOrString = Buffer | string
-
-export default class Minipass<
+declare class Minipass<
     RType extends any = Buffer,
-    WType extends any = RType extends BufferOrString ? ContiguousData : RType
+    WType extends any = RType extends Minipass.BufferOrString
+      ? Minipass.ContiguousData
+      : RType
   >
   extends Stream
-  implements DualIterable<RType>
+  implements Minipass.DualIterable<RType>
 {
-  static isStream(stream: any): stream is Readable | Writable
+  static isStream(stream: any): stream is Minipass.Readable | Minipass.Writable
 
   readonly bufferLength: number
   readonly flowing: boolean
@@ -48,7 +80,7 @@ export default class Minipass<
    * Not technically private or readonly, but not safe to mutate.
    */
   private readonly buffer: RType[]
-  private readonly pipes: Pipe<RType, WType>[]
+  private readonly pipes: Minipass.Pipe<RType, WType>[]
 
   /**
    * Technically writable, but mutating it can change the type,
@@ -70,31 +102,31 @@ export default class Minipass<
    * TypeScript does not provide many options for changing the type of
    * an object at run-time, which is what changing the encoding does.
    */
-  readonly encoding: Encoding
+  readonly encoding: Minipass.Encoding
   // setEncoding(encoding: Encoding): void
 
   // Options required if not reading buffers
   constructor(
     ...args: RType extends Buffer
-      ? [options?: Options<RType>]
-      : [options: Options<RType>]
+      ? [options?: Minipass.Options<RType>]
+      : [options: Minipass.Options<RType>]
   )
 
   write(chunk: WType, cb?: () => void): boolean
-  write(chunk: WType, encoding?: Encoding, cb?: () => void): boolean
+  write(chunk: WType, encoding?: Minipass.Encoding, cb?: () => void): boolean
   read(size?: number): RType
   end(cb?: () => void): this
   end(chunk: any, cb?: () => void): this
-  end(chunk: any, encoding?: Encoding, cb?: () => void): this
+  end(chunk: any, encoding?: Minipass.Encoding, cb?: () => void): this
   pause(): void
   resume(): void
   promise(): Promise<void>
   collect(): Promise<RType[]>
 
-  concat(): RType extends BufferOrString ? Promise<RType> : never
+  concat(): RType extends Minipass.BufferOrString ? Promise<RType> : never
   destroy(er?: any): void
-  pipe<W extends Writable>(dest: W, opts?: PipeOptions): W
-  unpipe<W extends Writable>(dest: W): void
+  pipe<W extends Minipass.Writable>(dest: W, opts?: Minipass.PipeOptions): W
+  unpipe<W extends Minipass.Writable>(dest: W): void
 
   /**
    * alias for on()
@@ -120,30 +152,4 @@ export default class Minipass<
   [Symbol.asyncIterator](): AsyncIterator<RType>
 }
 
-interface StringOptions {
-  encoding: BufferEncoding
-  objectMode?: boolean
-  async?: boolean
-}
-
-interface BufferOptions {
-  encoding?: null | 'buffer'
-  objectMode?: boolean
-  async?: boolean
-}
-
-interface ObjectModeOptions {
-  objectMode: true
-  async?: boolean
-}
-
-export declare interface PipeOptions {
-  end?: boolean
-  proxyErrors?: boolean
-}
-
-export declare type Options<T> = T extends string
-  ? StringOptions
-  : T extends Buffer
-  ? BufferOptions
-  : ObjectModeOptions
+export = Minipass

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.3.3",
   "description": "minimal implementation of a PassThrough stream",
   "main": "index.js",
+  "types": "index.d.ts",
   "dependencies": {
     "yallist": "^4.0.0"
   },


### PR DESCRIPTION
The acutal library uses CommonJS exports (`module.exports =`), but the type definitions use ES6 exports (`export` and `export default` keywords). This PR changes the types to use the `export =` syntax to match the library.

The difference between the two is that CommonJS exports allow the entire export be a class or function, while ES6 exports do not, even with `export default`.

```typescript
import Minipass = require('minipass')

// Invalid with current types
const stream = new Minipass()
```