### PR TITLE
Add types for the ESM version

### DIFF
--- a/index.d.mts
+++ b/index.d.mts
@@ -1,0 +1,18 @@
+import Minipass from "./index.js";
+
+export {
+    Encoding,
+    Writable,
+    Readable,
+    DualIterable,
+    ContiguousData,
+    BufferOrString,
+    SharedOptions,
+    StringOptions,
+    BufferOptions,
+    ObjectModeOptions,
+    PipeOptions,
+    Options
+} from "./index.js";
+
+export default Minipass;

--- a/index.d.ts
+++ b/index.d.ts
@@ -57,6 +57,16 @@ declare namespace Minipass {
     : ObjectModeOptions
 }
 
+interface Minipass<
+  RType extends any = Buffer,
+  WType extends any = RType extends Minipass.BufferOrString
+    ? Minipass.ContiguousData
+    : RType
+  >
+{
+  default: typeof Minipass;
+}
+
 declare class Minipass<
     RType extends any = Buffer,
     WType extends any = RType extends Minipass.BufferOrString

--- a/index.d.ts
+++ b/index.d.ts
@@ -57,16 +57,6 @@ declare namespace Minipass {
     : ObjectModeOptions
 }
 
-interface Minipass<
-  RType extends any = Buffer,
-  WType extends any = RType extends Minipass.BufferOrString
-    ? Minipass.ContiguousData
-    : RType
-  >
-{
-  default: typeof Minipass;
-}
-
 declare class Minipass<
     RType extends any = Buffer,
     WType extends any = RType extends Minipass.BufferOrString
@@ -157,4 +147,5 @@ declare class Minipass<
   [Symbol.asyncIterator](): AsyncGenerator<RType, void, void>
 }
 
-export = Minipass
+export default Minipass;
+export = Minipass;

--- a/index.js
+++ b/index.js
@@ -699,4 +699,5 @@ class Minipass extends Stream {
   }
 }
 
+Minipass.default = Minipass;
 module.exports = Minipass

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./index.d.ts",
+        "types": "./index.d.mts",
         "default": "./index.mjs"
       },
       "require": {


### PR DESCRIPTION
Currently, the types of `minipass` are declared to represent the `CommonJS` version of the module.
In order to use these types for the `ESM` version in a TypeScript project, people are forced to enable `esModuleInterop` in their `tsconfig.json` settings.

However, this might bring unwanted side effects (such as manipulated import behavior) and in some cases (for example when writing type declarations for `DefinitelyTyped`, using `esModuleInterop` isn't even allowed).

Changes made in this PR will add dedicated type declarations for the `ESM` version of the module which represent said version properly.

Furthermore, the `CommonJS` module has been updated in order to allow the `CommonJS` module to be default Imported from `CommonJS` TypeScript projects without the need to enable `esModuleInterop`. This allows modules such as `glob` to keep using the same TypeScript code for generating cjs and mjs versions of the module.

Actually, there are only a few change worth mentioning:
  - For the `ESM` version, the export of `Minipass` has been changed from an export assignment (`export = ...`) to a default export (`export default ...`).
  - For the `CommonJS` version, a default export has been added in addition to the already existing export assignment. Also the types were updated accordingly

This will allow TypeScript users creating an ESM project to use this dependency out of the box without any changes to their config. Furthermore, authors of DefinitelyTyped are able to author type declarations which have `minipass` somewhere in their dependency tree.

I'd love to have this included in a future patch update.