### PR TITLE
Bump node requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,6 @@
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)",
   "license": "ISC",
   "engines": {
-    "node": ">=16 || 14 >=14.17"
+    "node": ">=16 || 14 >=14.18"
   }
 }


### PR DESCRIPTION
https://github.com/isaacs/minipass/blob/b220db67d918c9717911ac5a05d427d2da6074d3/src/index.ts#L8

The `node:` import support to `require(...)` was added in Node.js 14.18. https://nodejs.org/api/esm.html#node-imports

`require("node:events")` is used in the cjs build of this library.