### PR TITLE
Node-prefixed requires

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2198,9 +2198,9 @@
       "dev": true
     },
     "node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
       "dev": true
     },
     "node_modules/is-actual-promise": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,9 @@ const proc =
         stdout: null,
         stderr: null,
       }
-import { EventEmitter } from 'events'
-import Stream from 'stream'
-import { StringDecoder } from 'string_decoder'
+import { EventEmitter } from 'node:events'
+import Stream from 'node:stream'
+import { StringDecoder } from 'node:string_decoder'
 
 /**
  * Same as StringDecoder, but exposing the `lastNeed` flag on the type


### PR DESCRIPTION
This changeset fixes and closes #54 by switching to `node:`-prefixed imports, which should be safe to assume support for now that Node 20 is LTS and Node 16 is EOL (Node 16 introduced this feature).

**Related issues:**
- isaacs/path-scurry#16
- isaacs/node-glob#580

**Peer PRs:**
- isaacs/path-scurry#17
- isaacs/node-glob#581